### PR TITLE
mt7668: add strip-debug to EXTRA_LDFLAGS for module build

### DIFF
--- a/drivers/bluetooth/mt7668u/Makefile
+++ b/drivers/bluetooth/mt7668u/Makefile
@@ -7,3 +7,6 @@ USB_CFILES := \
 $(USB_MOD_NAME)-objs := $(USB_CFILES:.c=.o)
 
 obj-$(CONFIG_BT_MT7668U) := $(USB_MOD_NAME).o
+ifeq ($(CONFIG_BT_MT7668U), m)
+EXTRA_LDFLAGS += --strip-debug
+endif

--- a/drivers/net/wireless/mediatek/mt7668/Makefile
+++ b/drivers/net/wireless/mediatek/mt7668/Makefile
@@ -115,6 +115,9 @@ ccflags-y += $(PLATFORM_FLAGS)
 endif
 
 obj-$(CONFIG_MT7668) += $(MODULE_NAME).o
+ifeq ($(CONFIG_MT7668), m)
+EXTRA_LDFLAGS += --strip-debug
+endif
 
 # ---------------------------------------------------
 # Directory List


### PR DESCRIPTION
It adds strip-debug to EXTRA_LDFLAGS for module build of MediaTek MT7668
bt/wifi combo module.

Signed-off-by: Jianguo Sun <sunjianguo1@huawei.com>