### PR TITLE
Fix build errors with GCC 8.1

### DIFF
--- a/drivers/msp/hifb/src/drv_hifb_proc.c
+++ b/drivers/msp/hifb/src/drv_hifb_proc.c
@@ -476,7 +476,7 @@ static inline HI_VOID HIFB_PROC_SetAlpha(HI_U32 u32LayerId, HI_CHAR *pCmd)
     HI_CHAR TmpCmd[HIFB_FILE_NAME_MAX_LEN]={0};
     HI_CHAR *pStr = HI_NULL;
 
-    strncpy(TmpCmd,pCmd,(HIFB_FILE_NAME_MAX_LEN-1));
+    strncpy(TmpCmd,pCmd,HIFB_FILE_NAME_MAX_LEN);
     TmpCmd[HIFB_FILE_NAME_MAX_LEN-1] = '\0';
 
     pStr = strstr(TmpCmd, "=");

--- a/drivers/msp/pvr/drv_pvr_intf.c
+++ b/drivers/msp/pvr/drv_pvr_intf.c
@@ -252,7 +252,8 @@ HI_S32 PVR_DRV_ModInit(HI_VOID)
     PvrFileOps.compat_ioctl	= PVR_DRV_Ioctl;
 #endif
 
-    strncpy(PvrDev.devfs_name, UMAP_DEVNAME_PVR, sizeof(UMAP_DEVNAME_PVR));
+    strncpy(PvrDev.devfs_name, UMAP_DEVNAME_PVR, sizeof(PvrDev.devfs_name));
+    PvrDev.devfs_name[sizeof(PvrDev.devfs_name)-1] = '\0';
     PvrDev.minor  = UMAP_MIN_MINOR_PVR;
     PvrDev.owner  = THIS_MODULE;
     PvrDev.fops	  = &PvrFileOps;

--- a/drivers/msp/vo/vdp_v4_0/drv/drv_display.c
+++ b/drivers/msp/vo/vdp_v4_0/drv/drv_display.c
@@ -4980,7 +4980,7 @@ HI_S32	DRV_DISP_O5_SetMacv(HI_BOOL bEnable)
 
     /*TODO: convert user macvision table to 5 bytes registers  */
     if (bEnable)
-	memcpy(u32macv, g_O5_u8MacvTable, sizeof(u32macv));
+	memcpy(u32macv, g_O5_u8MacvTable, sizeof(g_O5_u8MacvTable));
     else
 	memset(u32macv, 0x0, sizeof(u32macv));
 


### PR DESCRIPTION
Fixes the following errors:

  CC      drivers/msp/hifb/./src/drv_hifb_proc.o
In function ‘HIFB_PROC_SetAlpha’,
    inlined from ‘HIFB_ParseProcEchoCmd’ at drivers/msp/hifb/./src/drv_hifb_proc.c:404:8,
    inlined from ‘DRV_HIFB_WriteProc’ at drivers/msp/hifb/./src/drv_hifb_proc.c:293:5:
drivers/msp/hifb/./src/drv_hifb_proc.c:479:5: error: ‘strncpy’ output may be truncated copying 31 bytes from a string of length 255 [-Werror=stringop-truncation]
     strncpy(TmpCmd,pCmd,(HIFB_FILE_NAME_MAX_LEN-1));
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[...]
  CC      drivers/msp/pvr/drv_pvr_intf.o
drivers/msp/pvr/drv_pvr_intf.c: In function ‘PVR_DRV_ModInit’:
drivers/msp/pvr/drv_pvr_intf.c:255:56: error: argument to ‘sizeof’ in ‘strncpy’ call is the same expression as the source; did you mean to use the size of the destination? [-Werror=sizeof-pointer-memaccess]
     strncpy(PvrDev.devfs_name, UMAP_DEVNAME_PVR, sizeof(UMAP_DEVNAME_PVR));
                                                        ^
[...]
  CC      drivers/msp/vo/vdp_v4_0/drv/drv_display.o
drivers/msp/vo/vdp_v4_0/drv/drv_display.c: In function ‘DRV_DISP_O5_SetMacv’:
drivers/msp/vo/vdp_v4_0/drv/drv_display.c:4983:2: error: ‘memcpy’ forming offset [19, 20] is out of the bounds [0, 18] of object ‘g_O5_u8MacvTable’ with type ‘HI_U8[18]’ {aka ‘unsigned char[18]’} [-Werror=array-bounds]
  memcpy(u32macv, g_O5_u8MacvTable, sizeof(u32macv));
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/msp/vo/vdp_v4_0/drv/drv_display.c:4902:11: note: ‘g_O5_u8MacvTable’ declared here
 HI_U8     g_O5_u8MacvTable[18];
           ^~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>